### PR TITLE
구글 애널리틱스 붙이기

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,3 +18,6 @@ plugins:
 # Custom vars
 version:             1.1.0
 markdown: kramdown
+
+# Google Analytics
+g-analytics: G-EZFDSGJ1L5

--- a/_config.yml
+++ b/_config.yml
@@ -19,5 +19,9 @@ plugins:
 version:             1.1.0
 markdown: kramdown
 
-# Google Analytics
-g-analytics: G-EZFDSGJ1L5
+# Analytics
+analytics:
+  provider               : "google-gtag" # false (default), only possible "google-gtag"
+  google:
+    tracking_id          : "G-EZFDSGJ1L5"
+    anonymize_ip         : # true, false (default)

--- a/_includes/analytics-providers/google-gtag.html
+++ b/_includes/analytics-providers/google-gtag.html
@@ -1,0 +1,14 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script
+  async
+  src="https://www.googletagmanager.com/gtag/js?id=G-EZFDSGJ1L5"
+></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
+
+  gtag("config", "G-EZFDSGJ1L5");
+</script>

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,8 @@
+{% if jekyll.environment == 'production' and site.analytics.provider and page.analytics != false %}
+
+{% case site.analytics.provider %}
+{% when "google-gtag" %}
+  {% include /analytics-providers/google-gtag.html %}
+{% endcase %}
+
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,7 @@
   <body>
 
     {% include sidebar.html %}
+    {% include analytics.html %}
 
     <!-- Wrap is the content to shift when toggling the sidebar. We wrap the
          content to avoid any CSS collisions with our real content. -->
@@ -28,6 +29,5 @@
 
     <script src='{{ site.baseurl }}/public/js/script.js'></script>
 
-    {% include analytics.html %}
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,5 +27,7 @@
     <label for="sidebar-checkbox" class="sidebar-toggle"></label>
 
     <script src='{{ site.baseurl }}/public/js/script.js'></script>
+
+    {% include analytics.html %}
   </body>
 </html>


### PR DESCRIPTION
* google analytics 의 `measure_id` 를 활용했습니다.
* `_config.yml` 에 아래 정보를 추가했습니다.
```
# Analytics
analytics:
  provider               : "google-gtag" # false (default), only possible "google-gtag"
  google:
    tracking_id          : "G-EZFDSGJ1L5"
    anonymize_ip         : # true, false (default)
``` 
* `default.html`의 바디에 `analytics.html` 을 추가했습니다. `/analytics-providers/google-gtag.html` 을 참고하게 됩니다.


### 참고
* `tracking_id` 를 활용하는 예시가 인터넷에 많았는데 저는 `tracking_id` 를 추출하지 못했습니다ㅠ 
  * 그래서 다른 예시를 찾아보면서 `measure_id` 로 커스터마이징 했습니다. 
  * 혹시 다른 좋은 아이디어 있으시면 언제든지 말씀 부탁드립니다!
* 위 방법이 제 깃헙블로그에서는 애널리틱스가 붙는것을 확인 했지만 convex 블로그에서는 merge 되서야 확인이 될 것 같습니다. 
