### PR TITLE
Update open source contributors' profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,23 +119,8 @@ wgm0601@gmail.com / 우경민 (마키나락스)
 <!-- prettier-ignore-end -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-- 우경민(wgm0601@gmail.com)
-- 류원탁
-- 이민주
-- 정영재
-- 신훈철
-
-### Open Source Contributor
-
-- 박진우(www.jwpark.co.kr@gmail.com)
-- 우경민(wgm0601@gmail.com)
-- 류원탁
-- 신훈철
-- 정영재
-- 이민주
-- 김준우
-- 김민섭
-
+This project follows the [all-contributors](https://allcontributors.org) specification.
+Contributions of any kind are welcome!
 
 ## 다루는 내용들
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,15 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/enfow/"><img src="{{site.imgurl}}/profile/kyeongmin-woo.png" width="100px;" alt=""/><br /><sub><b>Kyeongmin Woo</b></sub></a><br /><a href="https://github.com/enfow/" title="Code">💻</a> <a href="https://github.com/enfow/" title="Documentation">📖</a></td>
+    <td align="center">
+      <a href="https://github.com/enfow/">
+        <img src="{{site.url}}/img/profile/kyeongmin-woo.png" width="100px;" alt=""/>
+        <br />
+        <sub><b>Kyeongmin Woo</b></sub></a>
+        <br />
+        <a href="https://github.com/enfow/" title="Code">💻</a> 
+        <a href="https://github.com/enfow/" title="Documentation">📖</a>
+    </td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Contributions of any kind are welcome!
 ## 다루는 내용들
 
 | idx | Title | 모두를 위한 컨벡스 최적화 | Lecture | Slide | Code Owner | 
-|---|---|---|---|---|---|
+|:---:|:---:|:---:|:---:|:---:|:---:|
 | 1 | Introduction | [Page](<https://wikidocs.net/17202>)  | [CMU Lecture](<https://www.youtube.com/watch?v=XFKBNJ14UmY&ab_channel=RyanT>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/lectures/intro.pdf>)  | 우경민 |
 | 2 | Convex Sets | [Page](<https://wikidocs.net/17370>)  | [Stanford Lecture](<https://www.youtube.com/watch?v=P3W_wFZ2kUo&list=PL3940DD956CDF0622&index=3&ab_channel=Stanford>)  | [Stanford Note](<https://web.stanford.edu/class/ee364a/lectures/sets.pdf>)  | 류원탁 |
 | 3 | Convex Functions | [Page](<https://wikidocs.net/17267>)  | [Stanford Lecture](<https://www.youtube.com/watch?v=kcOodzDGV4c&list=PL3940DD956CDF0622&index=4&ab_channel=Stanford>)  | [Stanford Note](<https://see.stanford.edu/materials/lsocoee364a/03ConvexFunctions.pdf>)  | 이민주 |

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center">
       <a href="https://github.com/enfow/">
-        <img src="{{site.url}}/img/profile/kyeongmin-woo.png" width="100px;" alt=""/>
+        <img src="./img/profile/kyeongmin-woo.png" width="100px;" alt=""/>
         <br />
         <sub><b>Kyeongmin Woo</b></sub></a>
         <br />

--- a/README.md
+++ b/README.md
@@ -156,6 +156,3 @@ Contributions of any kind are welcome!
 - [Stanford Convex Optimization Lecture 2014](<https://www.youtube.com/playlist?list=PL3940DD956CDF0622>)
 - [CMU Convex Optimization Lecture 2016](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)
 - [CMU Convex Optimization Lecture 2019](<http://www.stat.cmu.edu/~ryantibs/convexopt/>)
-
-
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Contributions of any kind are welcome!
 
 ## 다루는 내용들
 
+| idx | Title | CO for all | Lecture | Slide |
+|---|---|---|---|---|
+| 1 | Introduction | [Introduction](<https://wikidocs.net/17202>)  | [Lecture](<https://www.youtube.com/watch?v=XFKBNJ14UmY&ab_channel=RyanT>)  | [Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/lectures/intro.pdf>)  |
+
 1. Introduction
 2. Convex Sets
 3. Convex Functions

--- a/README.md
+++ b/README.md
@@ -124,34 +124,33 @@ Contributions of any kind are welcome!
 
 ## 다루는 내용들
 
-| idx | Title | 모두를 위한 컨벡스 최적화 | Lecture | Slide | Owner | 
-|---|---|---|---|---|
+| idx | Title | 모두를 위한 컨벡스 최적화 | Lecture | Slide | Code Owner | 
+|---|---|---|---|---|---|
 | 1 | Introduction | [Page](<https://wikidocs.net/17202>)  | [CMU Lecture](<https://www.youtube.com/watch?v=XFKBNJ14UmY&ab_channel=RyanT>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/lectures/intro.pdf>)  | 우경민 |
 | 2 | Convex Sets | [Page](<https://wikidocs.net/17370>)  | [Stanford Lecture](<https://www.youtube.com/watch?v=P3W_wFZ2kUo&list=PL3940DD956CDF0622&index=3&ab_channel=Stanford>)  | [Stanford Note](<https://web.stanford.edu/class/ee364a/lectures/sets.pdf>)  | 류원탁 |
 | 3 | Convex Functions | [Page](<https://wikidocs.net/17267>)  | [Stanford Lecture](<https://www.youtube.com/watch?v=kcOodzDGV4c&list=PL3940DD956CDF0622&index=4&ab_channel=Stanford>)  | [Stanford Note](<https://see.stanford.edu/materials/lsocoee364a/03ConvexFunctions.pdf>)  | 이민주 |
 | 4 | Convex Optimization Basis | [Page](<https://wikidocs.net/18335>)  | [CMU Lecture](<https://www.youtube.com/watch?v=Gij3dlqLUN8&list=PLjbUi5mgii6AVdvImLB9-Hako68p9MpIC&index=5&ab_channel=RyanT>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/lectures/convex-opt.pdf>)  |  정영재  |
 | 5 | Canonical Problems | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |  신훈철  |
-
-| 6 | Gradient Descent | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 7 | Subgradient | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 8 | Subgradient Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 9 | Proximal Gradient Descent and Acceleration | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 10 | Duality in Linear Programs | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 11 | Duality in General Programs | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 12 | KKT Conditions | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 13 | CanonicalDuality uses and correspondences | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 14 | Newton's Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 15 | Barrier Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 16 | Duality Revisited | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 6 | Gradient Descent | [Page](<https://wikidocs.net/18083>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 7 | Subgradient | [Page](<https://wikidocs.net/18714>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 8 | Subgradient Method | [Page](<https://wikidocs.net/18952>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 9 | Proximal Gradient Descent and Acceleration | [Page](<https://wikidocs.net/19031>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 10 | Duality in Linear Programs | [Page](<https://wikidocs.net/19932>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 11 | Duality in General Programs | [Page](<https://wikidocs.net/20582>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 12 | KKT Conditions | [Page](<https://wikidocs.net/20948>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 13 | CanonicalDuality uses and correspondences | [Page](<https://wikidocs.net/20949>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 14 | Newton's Method | [Page](<https://wikidocs.net/21007>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 15 | Barrier Method | [Page](<https://wikidocs.net/21297>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 16 | Duality Revisited | [Page](<https://wikidocs.net/21643>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
 | 17 | Primal-Dual Interior-Point Methods | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 18 | Quasi-Newton Methods | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 19 | Proximal Netwon Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 20 | Dual Methods | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 21 | Alternating Direction Method of Mulipliers | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 22 | Conditional Gradient Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 23 | Coordinate Descent | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 24 | Mixed Integer Programming 1 | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
-| 25 | Mixed Integer Programming 2 | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 18 | Quasi-Newton Methods | [Page](<https://wikidocs.net/21979>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 19 | Proximal Netwon Method | [Page](<https://wikidocs.net/22424>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 20 | Dual Methods | [Page](<https://wikidocs.net/22602>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 21 | Alternating Direction Method of Mulipliers | [Page](<https://wikidocs.net/22687>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 22 | Conditional Gradient Method | [Page](<https://wikidocs.net/22688>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 23 | Coordinate Descent | [Page](<https://wikidocs.net/23359>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 24 | Mixed Integer Programming 1 | [Page](<https://wikidocs.net/23447>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 25 | Mixed Integer Programming 2 | [Page](<https://wikidocs.net/23718>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
 
 ## 참고한 자료들
 

--- a/README.md
+++ b/README.md
@@ -124,35 +124,34 @@ Contributions of any kind are welcome!
 
 ## 다루는 내용들
 
-| idx | Title | CO for all | Lecture | Slide |
+| idx | Title | 모두를 위한 컨벡스 최적화 | Lecture | Slide | Owner | 
 |---|---|---|---|---|
-| 1 | Introduction | [Introduction](<https://wikidocs.net/17202>)  | [Lecture](<https://www.youtube.com/watch?v=XFKBNJ14UmY&ab_channel=RyanT>)  | [Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/lectures/intro.pdf>)  |
+| 1 | Introduction | [Page](<https://wikidocs.net/17202>)  | [CMU Lecture](<https://www.youtube.com/watch?v=XFKBNJ14UmY&ab_channel=RyanT>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/lectures/intro.pdf>)  | 우경민 |
+| 2 | Convex Sets | [Page](<https://wikidocs.net/17370>)  | [Stanford Lecture](<https://www.youtube.com/watch?v=P3W_wFZ2kUo&list=PL3940DD956CDF0622&index=3&ab_channel=Stanford>)  | [Stanford Note](<https://web.stanford.edu/class/ee364a/lectures/sets.pdf>)  | 류원탁 |
+| 3 | Convex Functions | [Page](<https://wikidocs.net/17267>)  | [Stanford Lecture](<https://www.youtube.com/watch?v=kcOodzDGV4c&list=PL3940DD956CDF0622&index=4&ab_channel=Stanford>)  | [Stanford Note](<https://see.stanford.edu/materials/lsocoee364a/03ConvexFunctions.pdf>)  | 이민주 |
+| 4 | Convex Optimization Basis | [Page](<https://wikidocs.net/18335>)  | [CMU Lecture](<https://www.youtube.com/watch?v=Gij3dlqLUN8&list=PLjbUi5mgii6AVdvImLB9-Hako68p9MpIC&index=5&ab_channel=RyanT>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/lectures/convex-opt.pdf>)  |  정영재  |
+| 5 | Canonical Problems | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |  신훈철  |
 
-1. Introduction
-2. Convex Sets
-3. Convex Functions
-4. Convex Optimization Basis
-5. Canonical Problems
-6. Gradient Descent
-7. Subgradient
-8. Subgradient Method
-9. Proximal Gradient Descent and Acceleration
-10. Duality in Linear Programs
-11. Duality in General Programs
-12. KKT Conditions
-13. Duality uses and correspondences
-14. Newton's Method
-15. Barrier Method
-16. Duality Revisited
-17. Primal-Dual Interior-Point Methods
-18. Quasi-Newton Methods
-19. Proximal Netwon Method
-20. Dual Methods
-21. Alternating Direction Method of Mulipliers
-22. Conditional Gradient Method
-23. Coordinate Descent
-24. Mixed Integer Programming 1
-25. Mixed Integer Programming 2
+| 6 | Gradient Descent | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 7 | Subgradient | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 8 | Subgradient Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 9 | Proximal Gradient Descent and Acceleration | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 10 | Duality in Linear Programs | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 11 | Duality in General Programs | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 12 | KKT Conditions | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 13 | CanonicalDuality uses and correspondences | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 14 | Newton's Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 15 | Barrier Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 16 | Duality Revisited | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 17 | Primal-Dual Interior-Point Methods | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 18 | Quasi-Newton Methods | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 19 | Proximal Netwon Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 20 | Dual Methods | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 21 | Alternating Direction Method of Mulipliers | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 22 | Conditional Gradient Method | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 23 | Coordinate Descent | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 24 | Mixed Integer Programming 1 | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
+| 25 | Mixed Integer Programming 2 | [Page](<https://wikidocs.net/17851>)  | [CMU Lecture](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/>)  |    |
 
 ## 참고한 자료들
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,82 @@ wgm0601@gmail.com / 우경민 (마키나락스)
 - 정태수 (tcheong@korea.ac.kr)
 - [리뷰어 소개](<https://wikidocs.net/17197>)
 
-### Open Source Migrator
+### Open Source Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center">
+      <a href="">
+        <img src="" width="100px;" alt=""/>
+        <br />
+        <sub><b>박진우</b></sub></a>
+        <br />
+        <a href="" title="Code">💻</a> 
+        <a href="" title="Documentation">📖</a>
+    </td>
+    <td align="center">
+      <a href="https://www.linkedin.com/in/enfow/">
+        <img src="./img/profile/kyeongmin-woo.png" width="100px;" alt=""/>
+        <br />
+        <sub><b>우경민</b></sub></a>
+        <br />
+        <a href="https://github.com/enfow/" title="Code">💻</a> 
+        <a href="https://www.linkedin.com/in/enfow/" title="Documentation">📖</a>
+    </td>
+    <td align="center">
+      <a href="">
+        <img src="" width="100px;" alt=""/>
+        <br />
+        <sub><b>류원탁</b></sub></a>
+        <br />
+        <a href="" title="Code">💻</a> 
+        <a href="" title="Documentation">📖</a>
+    </td>
+    <td align="center">
+      <a href="">
+        <img src="" width="100px;" alt=""/>
+        <br />
+        <sub><b>이민주</b></sub></a>
+        <br />
+        <a href="" title="Code">💻</a> 
+        <a href="" title="Documentation">📖</a>
+    </td>
+    <td align="center">
+      <a href="">
+        <img src="" width="100px;" alt=""/>
+        <br />
+        <sub><b>정영재</b></sub></a>
+        <br />
+        <a href="" title="Code">💻</a> 
+        <a href="" title="Documentation">📖</a>
+    </td>
+    <td align="center">
+      <a href="">
+        <img src="" width="100px;" alt=""/>
+        <br />
+        <sub><b>신훈철</b></sub></a>
+        <br />
+        <a href="" title="Code">💻</a> 
+        <a href="" title="Documentation">📖</a>
+    </td>
+    <td align="center">
+      <a href="">
+        <img src="" width="100px;" alt=""/>
+        <br />
+        <sub><b>김민섭</b></sub></a>
+        <br />
+        <a href="" title="Code">💻</a> 
+        <a href="" title="Documentation">📖</a>
+    </td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 - 우경민(wgm0601@gmail.com)
 - 류원탁
@@ -99,23 +174,3 @@ wgm0601@gmail.com / 우경민 (마키나락스)
 
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tr>
-    <td align="center">
-      <a href="https://github.com/enfow/">
-        <img src="./img/profile/kyeongmin-woo.png" width="100px;" alt=""/>
-        <br />
-        <sub><b>Kyeongmin Woo</b></sub></a>
-        <br />
-        <a href="https://github.com/enfow/" title="Code">💻</a> 
-        <a href="https://github.com/enfow/" title="Documentation">📖</a>
-    </td>
-  </tr>
-</table>
-
-<!-- markdownlint-enable -->
-<!-- prettier-ignore-end -->
-<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
# This PR will be merged when all of the contributors update their own profile!

# Done

- Replace list style profile to image based profile with all-contributors.
  - [all-contributors homepage](<https://allcontributors.org/docs/en/overview>)
- Aggregate migrator and contributor profile.
- Update Contents List

# How to set your own profile by yourself?

the example of a profile is looks like below

```html
    <td align="center">
      <a href="https://www.linkedin.com/in/enfow/">   
        <img src="./img/profile/kyeongmin-woo.png" width="100px;" alt=""/>  
        <br />
        <sub><b>우경민</b></sub></a>
        <br />
        <a href="https://github.com/enfow/" title="Code">💻</a> 
        <a href="https://www.linkedin.com/in/enfow/" title="Documentation">📖</a>
    </td>
```

0. find your own profile.
1. fix url to move when image is clicked (It can be anything you want. I set it as my linkedin profile url.)

```
 <a href="https://www.linkedin.com/in/enfow/">   
```

2. add image on `img/profile` directory
3. fix image location

```
<img src="./img/profile/kyeongmin-woo.png" width="100px;" alt=""/>  
```

4. fix additional url information as you want. (If you don't need it, just delete it)

```
<a href="https://github.com/enfow/" title="Code">💻</a> 
<a href="https://www.linkedin.com/in/enfow/" title="Documentation">📖</a>
```