### PR TITLE
Change title splitter

### DIFF
--- a/src/change_issue_title.py
+++ b/src/change_issue_title.py
@@ -12,6 +12,6 @@ if __name__ == "__main__":
 
     original_title = requests.get(url, auth=("username", token)).json()["title"]
     payload = {
-        "title": "[Closed] " + original_title.split("|", maxsplit=1)[0]
+        "title": "[Closed] " + original_title.split("·", maxsplit=1)[0]
     }
     requests.patch(url, auth=("username", token), json=payload)


### PR DESCRIPTION
Github Action으로 Issue 제목을 변경해주는 방식을 변경합니다.

### 버그내용
* Post 제목과 책 제목이 연결되는 Separator가 "|" 대신 "·" 되어야 합니다.

## #56 내용
### 기존 문제점
* 포스트와 연결된 댓글용 이슈를 찾을 때 제목을 기반으로 찾습니다.
* Closed되어도 Closed된 이슈에 계속해서 새로운 댓글이 달릴 수 있는 문제가 있습니다.

### PR로 해결한 내용
* Issue를 Close할 때 Github Action을 이용해 Issue 제목을 자동을 변경합니다.
* 변경된 제목이 기존 제목을 모두 포함하면 변경된 것으로 인식을 못하는 문제가 있어 Post 제목 외에 책 제목을 지워주도록 설정했습니다.