### PR TITLE
Fix related posts system

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,10 +13,8 @@ layout: default
 
 {% assign post_order = page.order%}
 
-{% assign post_before_before = page.order | minus: 2 %}
 {% assign post_before = page.order | minus: 1 %}
 {% assign post_after = page.order | plus: 1 %}
-{% assign post_after_after = page.order | plus: 2 %}
 
 {% if post_list.size >= 2 %}
 <div class="related">
@@ -24,10 +22,8 @@ layout: default
   <ul class="related-posts">
     {% for post in post_list%}
       {% if 
-        post.order == post_before_before or 
         post.order == post_before or 
-        post.order == post_after or
-        post.order == post_after_after 
+        post.order == post_after
       %}
         <li>
           <h3>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,19 +8,36 @@ layout: default
   {{ content }}
 </div>
 
-{% if site.related_posts.size >= 1 %}
+{% assign full_name = page.chapter | prepend: "chapter" %}
+{% assign post_list = site.categories[full_name] | sort_natural: "order" %}
+
+{% assign post_order = page.order%}
+
+{% assign post_before_before = page.order | minus: 2 %}
+{% assign post_before = page.order | minus: 1 %}
+{% assign post_after = page.order | plus: 1 %}
+{% assign post_after_after = page.order | plus: 2 %}
+
+{% if post_list.size >= 2 %}
 <div class="related">
   <h2>Related posts</h2>
   <ul class="related-posts">
-    {% for post in site.related_posts limit:3 %}
-      <li>
-        <h3>
-          <a href="{{ site.baseurl }}{{ post.url }}">
-            {{ post.title }}
-            <small>{{ post.date | date_to_string }}</small>
-          </a>
-        </h3>
-      </li>
+    {% for post in post_list%}
+      {% if 
+        post.order == post_before_before or 
+        post.order == post_before or 
+        post.order == post_after or
+        post.order == post_after_after 
+      %}
+        <li>
+          <h3>
+            <a href="{{ site.baseurl }}{{ post.url }}">
+              {{ post.title }}
+              <small> {{ post.date | date_to_string }}</small>
+            </a>
+          </h3>
+        </li>
+      {% endif %}
     {% endfor %}
   </ul>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -30,17 +30,19 @@ layout: default
           </h3>
         </li>
       {% endif %}
-      {% if post.order == post_after %}
-        <li>
-          <h2>Next Post</h2>
-          <h3>
-            <a href="{{ site.baseurl }}{{ post.url }}">
-              {{ post.title }}
-            </a>
-          </h3>
-        </li>
-      {% endif %}
     {% endfor %}
+    {% for post in post_list%}
+    {% if post.order == post_after %}
+      <li>
+        <h2>Next Post</h2>
+        <h3>
+          <a href="{{ site.baseurl }}{{ post.url }}">
+            {{ post.title }}
+          </a>
+        </h3>
+      </li>
+    {% endif %}
+  {% endfor %}
   </ul>
 </div>
 {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -22,7 +22,7 @@ layout: default
     {% for post in post_list%}
       {% if post.order == post_before %}
         <li>
-          <h2>Post Before</h2>
+          <h2>Previous Post</h2>
           <h3>
             <a href="{{ site.baseurl }}{{ post.url }}">
               {{ post.title }}
@@ -32,7 +32,7 @@ layout: default
       {% endif %}
       {% if post.order == post_after %}
         <li>
-          <h2>Post After</h2>
+          <h2>Next Post</h2>
           <h3>
             <a href="{{ site.baseurl }}{{ post.url }}">
               {{ post.title }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,18 +18,24 @@ layout: default
 
 {% if post_list.size >= 2 %}
 <div class="related">
-  <h2>Related posts</h2>
   <ul class="related-posts">
     {% for post in post_list%}
-      {% if 
-        post.order == post_before or 
-        post.order == post_after
-      %}
+      {% if post.order == post_before %}
         <li>
+          <h2>Post Before</h2>
           <h3>
             <a href="{{ site.baseurl }}{{ post.url }}">
               {{ post.title }}
-              <small> {{ post.date | date_to_string }}</small>
+            </a>
+          </h3>
+        </li>
+      {% endif %}
+      {% if post.order == post_after %}
+        <li>
+          <h2>Post After</h2>
+          <h3>
+            <a href="{{ site.baseurl }}{{ post.url }}">
+              {{ post.title }}
             </a>
           </h3>
         </li>


### PR DESCRIPTION
## Done

- Change the mechanism to select related post.

## As-is

- below image shows the related posts list on post **<02-01-01 Line, line segment, ray>.**
- It shows just recent posts.
- According to [jekyll docs](<https://jekyllrb-ko.github.io/docs/variables/>), the related_post property includes the recent posts.

<img width="747" alt="Screen Shot 2021-03-26 at 8 05 40 PM" src="https://user-images.githubusercontent.com/31348169/112622642-a7eff600-8e6e-11eb-805a-3a24b1e73820.png">

## To-be

- with this PR, it select related post with order property. (on  **<02-01-01 Line, line segment, ray>.**)

<img width="751" alt="Screen Shot 2021-03-30 at 10 39 07 PM" src="https://user-images.githubusercontent.com/31348169/112998488-0ab3fb00-91a9-11eb-852a-6627e1dbbd04.png">

