### PR TITLE
Remove date info from post

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,6 @@ layout: default
 
 <div class="post">
   <h1 class="post-title">{{ page.title }}</h1>
-  <span class="post-date">{{ page.date | date_to_string }}</span>
   {{ content }}
 </div>
 


### PR DESCRIPTION
# Related Issue

- #93 

# As Is

<img width="786" alt="Screen Shot 2021-05-02 at 8 58 00 AM" src="https://user-images.githubusercontent.com/31348169/116797789-9ad8bd80-ab24-11eb-9b19-f01bdb42c1bf.png">

# To Be

<img width="834" alt="Screen Shot 2021-05-02 at 8 58 05 AM" src="https://user-images.githubusercontent.com/31348169/116797795-9f04db00-ab24-11eb-9670-5e40f28ea98a.png">