### PR TITLE
[HotFix] Fix markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ wgm0601@gmail.com / 우경민 (마키나락스)
 ## 다루는 내용들
 
 | idx | Title | Book | Lecture | Slide |
-|:---:|:---:|:---:|:---:|:---:|:---:|
+|:---:|:---:|:---:|:---:|:---:|
 | 1 | Introduction | [Page](<https://wikidocs.net/17202>)  | [CMU Lecture](<https://www.youtube.com/watch?v=XFKBNJ14UmY&ab_channel=RyanT>)  | [CMU Note](<http://www.stat.cmu.edu/~ryantibs/convexopt-F16/lectures/intro.pdf>)  |
 | 2 | Convex Sets | [Page](<https://wikidocs.net/17370>)  | [Stanford Lecture](<https://www.youtube.com/watch?v=P3W_wFZ2kUo&list=PL3940DD956CDF0622&index=3&ab_channel=Stanford>)  | [Stanford Note](<https://web.stanford.edu/class/ee364a/lectures/sets.pdf>)  |
 | 3 | Convex Functions | [Page](<https://wikidocs.net/17267>)  | [Stanford Lecture](<https://www.youtube.com/watch?v=kcOodzDGV4c&list=PL3940DD956CDF0622&index=4&ab_channel=Stanford>)  | [Stanford Note](<https://see.stanford.edu/materials/lsocoee364a/03ConvexFunctions.pdf>)  |


### PR DESCRIPTION
## Problems

- Contents table on README does not works

## As Is

<img width="1112" alt="Screen Shot 2021-05-08 at 12 44 55 PM" src="https://user-images.githubusercontent.com/31348169/117525003-40939d00-affb-11eb-80b3-2fdff0beee62.png">

## To Be

<img width="866" alt="Screen Shot 2021-05-08 at 12 45 00 PM" src="https://user-images.githubusercontent.com/31348169/117524999-3e314300-affb-11eb-909e-59ff6b719619.png">
