### PR TITLE
Make the sidebar overlap the viewport content

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 
   {% include head.html %}
 
-  <body>
+  <body class="sidebar-overlay">
 
     {% include sidebar.html %}
 


### PR DESCRIPTION
#142 

## AS-IS
![image](https://user-images.githubusercontent.com/36983960/119248597-2ea22480-bbcd-11eb-84f6-47fb121b8e33.png)
![image](https://user-images.githubusercontent.com/36983960/119248603-3cf04080-bbcd-11eb-93f2-d80656e446ac.png)

## TO-BE
<img width="2996" alt="스크린샷 2021-05-23 오후 6 28 28" src="https://user-images.githubusercontent.com/14961526/119255067-acc5f180-bbf4-11eb-85a3-1670942c123d.png">
<img width="2992" alt="스크린샷 2021-05-23 오후 6 28 42" src="https://user-images.githubusercontent.com/14961526/119255075-b51e2c80-bbf4-11eb-8dd7-186269779094.png">
