### PR TITLE
[chapter11 typo] Change plus sign to minus

### DIFF
--- a/contents/chapter11/_posts/21-03-24-11_02_Lagrange_dual_function.md
+++ b/contents/chapter11/_posts/21-03-24-11_02_Lagrange_dual_function.md
@@ -66,7 +66,7 @@ Qx - (c-u+A^T v) = 0,
 \begin{equation}
 Qx = (c-u+A^T v) 
 \end{equation}
-이 때, $$Q$$는 positive definite하므로 역행렬이 존재하므로, $$x^*$$를 찾으면, $$x^* = Q^{-1}(c + u + A^Tv)$$ 임을 알 수 있다. 따라서, $$x^*$$를 Lagrangian 함수에 대입을 하면, 아래를 얻을 수 있다. 
+이 때, $$Q$$는 positive definite하므로 역행렬이 존재하므로, $$x^*$$를 찾으면, $$x^* = Q^{-1}(c - u + A^Tv)$$ 임을 알 수 있다. 따라서, $$x^*$$를 Lagrangian 함수에 대입을 하면, 아래를 얻을 수 있다. 
 
 $$
 \begin{alignat}{1}


### PR DESCRIPTION
Chapter 11에 오타를 수정했습니다.
plus sign이 문맥상 minus가 돼야 할 것 같습니다.

![스크린샷 2021-05-26 오후 10 15 40](https://user-images.githubusercontent.com/42792260/119666195-1e5da400-be70-11eb-89f4-1a0b176cf5b6.png)
