### PR TITLE
Fix image url for chapter06

### DIFF
--- a/contents/chapter06/_posts/21-03-20-06_01_gradient_descent.md
+++ b/contents/chapter06/_posts/21-03-20-06_01_gradient_descent.md
@@ -33,7 +33,7 @@ Gradient descent는 초기 점 $$x^{(0)} \in R^n$$을 선택하고 다음 식을
 
 <figure class="image" style="align: center;">
 <p align="center">
-  <img src="{{ site.baseurl  }}/img/chapter_img/chapter06/06_01_gradientdescent1.PNG" alt="gradientdescent1" width="80%" height="80%">
+  <img src="{{ site.baseurl }}/img/chapter_img/chapter06/06_01_gradientdescent1.PNG" alt="gradientdescent1" width="80%" height="80%">
   <figcaption style="text-align: center;">[Fig 1] Gradient descent in convex functions[3]</figcaption>
 </p>
 </figure>
@@ -42,7 +42,7 @@ Gradient descent는 초기 점 $$x^{(0)} \in R^n$$을 선택하고 다음 식을
 
 <figure class="image" style="align: center;">
 <p align="center">
-  <img src="{{ site.baseurl  }}/img/chapter_img/chapter06/06_01_gradientdescent2.PNG" alt="gradientdescent2" width="80%" height="80%">
+  <img src="{{ site.baseurl }}/img/chapter_img/chapter06/06_01_gradientdescent2.PNG" alt="gradientdescent2" width="80%" height="80%">
   <figcaption style="text-align: center;">[Fig 2] Gradient descent in non-convex functions[3]</figcaption>
 </p>
 </figure>
@@ -70,7 +70,7 @@ f(y) \approx f(x) + \nabla f(x)^T (y - x) +  \frac{1}{2t}  \parallel y - x  \par
 
 <figure class="image" style="align: center;">
 <p align="center">
-  <img src="{{ site.baseurl  }}/img/chapter_img/chapter06/06_01_gradientdescent3.PNG" alt="gradientdescent3" width="80%" height="80%">
+  <img src="{{ site.baseurl }}/img/chapter_img/chapter06/06_01_gradientdescent3.PNG" alt="gradientdescent3" width="80%" height="80%">
   <figcaption style="text-align: center;">$$ \text{[Fig 3] Gradient descent algorithm : red dot is } x^+ \text{ and blue dot } x \text{ [3]} $$</figcaption>
 </p>
 </figure>

--- a/contents/chapter06/_posts/21-03-20-06_02_01_fixed_step_size.md
+++ b/contents/chapter06/_posts/21-03-20-06_02_01_fixed_step_size.md
@@ -12,7 +12,7 @@ Gradient decent에서 step size를 찾는 가장 단순한 방법은 모든 반�
 
 <figure class="image" style="align: center;">
 <p align="center">
-  <img src="{{ site.baseurl  }}/img/chapter_img/chapter06/06_02_01_gradientdescent4.PNG" alt="gradientdescent4" width="100%" height="100%">
+  <img src="{{ site.baseurl }}/img/chapter_img/chapter06/06_02_01_gradientdescent4.PNG" alt="gradientdescent4" width="100%" height="100%">
   <figcaption style="text-align: center;">[Fig 1] Step size different scenarios [3]</figcaption>
 </p>
 </figure>

--- a/contents/chapter06/_posts/21-03-20-06_02_02_backtracking_line_search.md
+++ b/contents/chapter06/_posts/21-03-20-06_02_02_backtracking_line_search.md
@@ -69,7 +69,7 @@ Backtracking 방식으로 adaptive하게 step size를 선정하게 되면 fixed 
 
 <figure class="image" style="align: center;">
 <p align="center">
-  <img src="{{ site.baseurl  }}/img/chapter_img/chapter06/06_02_02_f_leq_app.png" alt="f_leq_app" width="60%" height="60%">
+  <img src="{{ site.baseurl }}/img/chapter_img/chapter06/06_02_02_f_leq_app.png" alt="f_leq_app" width="60%" height="60%">
   <figcaption style="text-align: center;">[Fig 3] f is less than the approximation of the next step</figcaption>
 </p>
 </figure>
@@ -80,7 +80,7 @@ Quadratic approximator가 $$x - t \nabla f(x)$$에서 더 위에 위치하는 �
 
 <figure class="image" style="align: center;">
 <p align="center">
-  <img src="{{ site.baseurl  }}/img/chapter_img/chapter06/06_02_02_f_geq_app.png" alt="f_geq_app" width="60%" height="60%">
+  <img src="{{ site.baseurl }}/img/chapter_img/chapter06/06_02_02_f_geq_app.png" alt="f_geq_app" width="60%" height="60%">
   <figcaption style="text-align: center;">[Fig 4] f is greater than the approximation of the next step</figcaption>
 </p>
 </figure>

--- a/contents/chapter06/_posts/21-03-20-06_04_gradient_boosting.md
+++ b/contents/chapter06/_posts/21-03-20-06_04_gradient_boosting.md
@@ -33,7 +33,7 @@ owner: "Kyeongmin Woo"
 
 <figure class="image" style="align: center;">
 <p align="center">
-  <img src="{{ site.baseurl  }}/img/chapter_img/chapter06/06_04_tree_O9zyAlk.png" alt="tree_O9zyAlk" width="80%" height="80%">
+  <img src="{{ site.baseurl }}/img/chapter_img/chapter06/06_04_tree_O9zyAlk.png" alt="tree_O9zyAlk" width="80%" height="80%">
   <figcaption style="text-align: center;">$$\text{[Fig 1] Example of Tree }T_j\text{ [3]}$$</figcaption>
 </p>
 </figure>


### PR DESCRIPTION
# Problem

- Some images in chapter 06 do not show on web(but it show on the local).

# Solution

- Remove whitespace from image url: `{{ site.baseurl  }}` -> `{{ site.baseurl }}`
  - The Image `Linear Convergence` on 06-03-04 shows correctly on the web.
  - It has single whitespace after site.baseurl.

# Related Issue

#177 (Thanks to @cneyang)