### PR TITLE
Fix typo in 15-02 Central Path example

### DIFF
--- a/contents/chapter15/_posts/21-03-28-15_02_central_path.md
+++ b/contents/chapter15/_posts/21-03-28-15_02_central_path.md
@@ -21,7 +21,7 @@ owner: "Minjoo Lee"
 다음의 LP 문제에 대한 central path를 구해보자.
 >$$\begin{align*}
 >&\min_{x} \ && c^Tx \\
->&\text{subject to } \ && a_i^Tx = b_i^T, i = 1, \cdots , 6 \\
+>&\text{subject to } \ && a_i^Tx \le b_i^T, i = 1, \cdots , 6 \\
 >\end{align*}$$
 
 다음 그림에서 점선은 logarithmic barrier function $$\phi$$를 나타낸다. <br>


### PR DESCRIPTION
Fixed the equality constraint to the inequality constraint.

- Ref: https://web.stanford.edu/~boyd/cvxbook/bv_cvxslides.pdf
<img width="1045" src="https://user-images.githubusercontent.com/14961526/194831047-8fe2c569-93f5-48b7-92d1-bf2de186d247.png">
