### PR TITLE
Fix the invalid hyperlink in 09-05-03 Example: FISTA

### DIFF
--- a/contents/chapter09/_posts/20-01-08-09_05_03_example_FISTA.md
+++ b/contents/chapter09/_posts/20-01-08-09_05_03_example_FISTA.md
@@ -16,7 +16,8 @@ owner: "Kyeongmin Woo"
 
 > $$\min_\beta \frac{1}{2} \lVert y−X\beta \rVert_2^2 + \lambda \lVert \beta \rVert_1$$
 
-그리고, ISTA의 정의도 기억해 보자.  $$S_\lambda (·)$$는 vector soft-thresholding일 떄 Proximal gradient update가 다음과 같이 정의되었었다. ([09-01 Proximal gradient descent](chapter09/2020/01/08/09_01_proximal_gradient_descent/) 참조)
+그리고, ISTA의 정의도 기억해 보자.  $$S_\lambda (·)$$는 vector soft-thresholding일 떄 Proximal gradient update가 다음과 같이 정의되었었다.
+([09-01 Proximal gradient descent]({% post_url contents/chapter09/20-01-08-09_01_proximal_gradient_descent %}) 참조)
 > $$\beta^{(k)} = S_{\lambda t_k} (\beta^{(k−1)} + t_kX^T(y − X\beta^{(k−1)})), k = 1,2,3,...$$
 
 이 식에 acceleration을 적용하면 $$\beta$$ 대신에 $$v$$를 계산해서 proximal gradient update를 한다.


### PR DESCRIPTION
Issue: https://github.com/convex-optimization-for-all/convex-optimization-for-all.github.io/issues/203#issuecomment-1273406957

## Test (docker-compose)

<img width="803" alt="스크린샷 2022-11-05 오전 10 35 56" src="https://user-images.githubusercontent.com/14961526/200095328-0b9669c8-cb70-422a-814e-ed51688081e6.png">

moves to

<img width="1062" alt="스크린샷 2022-11-05 오전 10 36 16" src="https://user-images.githubusercontent.com/14961526/200095340-8d906898-80ed-4ed1-b24b-e668fc04d15f.png">
