### PR TITLE
fix proof, dots, and Sigma notation in latex

### DIFF
--- a/contents/chapter01/_posts/21-01-07-01_01_optimization_problems.md
+++ b/contents/chapter01/_posts/21-01-07-01_01_optimization_problems.md
@@ -13,8 +13,8 @@ Mathematical optimization problem은 다음과 같은 형태로 표현될 수 �
 
 >$$\begin{align*} 
 >&\min_{x\in D}\ && f(x) \\
->&\text{subject to} && g_i(x) \le 0,\ i = 1, ...m \\
->&&& h_j(x) = 0,\ j = 1,\ ...r 
+>&\text{subject to} && g_i(x) \le 0,\ i = 1, ..., m \\
+>&&& h_j(x) = 0,\ j = 1,\ ..., r
 >\end{align*}$$
 
 **Mathematical Optimization Problem in standard form [3]**
@@ -22,13 +22,13 @@ Mathematical optimization problem은 다음과 같은 형태로 표현될 수 �
 * $$x \in R^n$$ is the optimization variable
 * $$f: R^n \rightarrow R$$ is the objective or cost function
 * $$g_i: R^n \rightarrow R, i = 1, ..., m$$ are the inequality constraint functions
-* $$h_i: R^n \rightarrow R, j = 1, ..., r$$ are the equality constraint functions
+* $$h_j: R^n \rightarrow R, j = 1, ..., r$$ are the equality constraint functions
 
 위의 제약조건을 모두 만족하는 정의역(feasible domain)에서 objective function f를 최소로 만드는 벡터 $$x$$를 $$x^*$$로 표시하고 이를 optimal solution이라 부른다. [1]
 
 제약조건의 경우 다음과 같이 두 가지로 구분될 수 있다. [2]
 
-1. Explicit constraints: 말 그대로 optimization problem에 직접적으로 명시된 제약조건을 뜻한다. 위에서 서술한 optimization problem의 standard form에서 함수 $$g_i$$와 $$h_i$$로 표현된 제약조건이 이에 해당한다. 참고로 explicit constraint가 없는 문제를 unconstrained problem이라고 부른다.
+1. Explicit constraints: 말 그대로 optimization problem에 직접적으로 명시된 제약조건을 뜻한다. 위에서 서술한 optimization problem의 standard form에서 함수 $$g_i$$와 $$h_j$$로 표현된 제약조건이 이에 해당한다. 참고로 explicit constraint가 없는 문제를 unconstrained problem이라고 부른다.
 2. Implicit constraints: Optimization problem에 직접적으로 명시되지 않는 제약조건을 말한다. 이는 Objective function과 모든 constraint function들의 정의역에 대한 교집합이다.
 
 $$D = dom(f) \cap \bigcap_{i=1}^m {\rm dom}(g_i) \cap \bigcap_{j=1}^r dom(h_j)$$<br/>
@@ -39,11 +39,11 @@ $$D = dom(f) \cap \bigcap_{i=1}^m {\rm dom}(g_i) \cap \bigcap_{j=1}^r dom(h_j)$$
 >
 >최적화 문제가 다음과 같이 주어졌다고 하자.
 >
->$$\begin{align*} \text{minimize } & & log(x) \end{align*}$$
+>$$\begin{align*} \text{minimize } & & \log(x) \end{align*}$$
 >
 >여기서 objective function인 log함수의 정의역이 $$x > 0$$이므로 $$x > 0$$이 이 문제에서의 implicit constraint가 된다. 이 문제를 explicit constraint가 포함된 형태의 최적화문제로 표현하면 다음과 같다.
 >
->$$\begin{align*} &\text{minimize } &&log(x) \\ &\text{subject to } &&x > 0 \end{align*}$$
+>$$\begin{align*} &\text{minimize } && \log(x) \\ &\text{subject to } &&x > 0 \end{align*}$$
 
 ## Applications
 

--- a/contents/chapter01/_posts/21-01-28-01_02_convex_optimization_problem.md
+++ b/contents/chapter01/_posts/21-01-28-01_02_convex_optimization_problem.md
@@ -10,8 +10,8 @@ Convex optimization problem은 optimization problem의 한 종류이다.
 
 >$$\begin{align*} 
 >&\min_{x\in D}\ &&f(x) \\
->&\text{subject to} && g_i(x) \le 0,\ i = 1, ...m \\
->&&& h_j(x) = 0,\ j = 1,\ ...r 
+>&\text{subject to} && g_i(x) \le 0,\ i = 1, ..., m \\
+>&&& h_j(x) = 0,\ j = 1,\ ..., r
 >\end{align*}$$
 
 **Convex Optimization Problem in standard form [3]**
@@ -79,30 +79,28 @@ $$
 
 ## Nice property of convex optimization problems
 Convex 함수의 local minimum은 항상 global minimum이다. convex optimization problem의 경우 non-convex optimization problem에 비해 일반적으로 solution을 더 쉽게 구할 수 있는데, 그 이유는 convex 함수가 다음과 같은 특성을 가지기 때문이다.
->$$f$$가 convex이고 $$x$$가 $$f(x)$$의 locally optimal point일때(즉 $$f(x)$$가 local minimum), 사실 x는 globally optimal point이다.
+>$$f$$가 convex이고 $$x$$가 $$f(x)$$의 locally optimal point일 때(즉 $$f(x)$$가 local minimum), x는 globally optimal point이다.
 
 이를 한번 증명해보자.
 
 >**proof by contradiction:**
 >
->Convex function f에 대해 $$x$$가 locally optimal point일때, 어딘가에 $$f(y) < f(x)$$를 만족하는 feasible $$y$$가 있다고 가정하자. (이 가정이 참임이 증명된다면 'locally optimal point = global optimal point'가 성립하지 않을 것이다.)
->
->$$x$$가 locally optimal point라는 것은 다음을 만족하는 양수 $$R$$이 존재한다는 것과 같다: 
->$$z$$ feasible, $$\vert z - x \vert_2 \le R \Rightarrow f(z) \ge f(x)$$
->
->이때 $$z = \theta y + (1 - \theta) x$$라고 하면 ($$0 < \theta < 1$$),
->
+>Convex function f에 대해 $$x$$가 globally optimal이 아닌 locally optimal point라고 하자.
+>또, feasible $$y$$를 global optimal point라고 하면, $$y$$는 임의의 양수 $$\rho$$에 대해 $$\|y - x\|_2 > \rho$$이고, $$f(y) < f(x)$$이 성립한다. (왜냐하면, $$x$$가 locally optimal이므로 $$\|x - y\|_2 \le \rho$$ 이면 $$f(x) \le f(y)$$이기 때문이고, 이는 $$y$$가 global optimal point임에 위배된다.)
+>이때, $$\theta=\frac{\rho}{2\|y-x\|_2}$$에 대해 $$z = \theta y + (1 - \theta) x=x + \theta( y - x)$$라고 하자.
 >1.$$\phantom{1} z$$는 두 개의 feasible points $$x, y$$에 대한 convex combination*이므로 또한 feasible하다.
 >
->2.$$\phantom{1}$$가정한 것처럼 $$f(y) < f(x)$$가 성립한다면, 이는 곧 $$f(z) \le \theta f(y) + (1 - \theta) f(x) < \theta f(x) + (1 - \theta) f(x) = f(x)$$
+>2.$$\phantom{1}\|z - x\|_2 = \theta \|y - x\|_2 = \frac{\rho}{2} < \rho$$ 이다.
 >
->2는 x가 locally optimal point이기 위한 전제조건 $$f(z) \ge f(x)$$에 대한 모순이므로 $$f(y)<f(x)$$를 만족하는 feasible y는 존재하지 않는다. 즉, locally optimal point x가 곧 globally optimal point임을 의미한다.
+>3.$$\phantom{1} f(z) \le \theta f(y) + (1 - \theta) f(x) < \theta f(x) + (1 - \theta) f(x) = f(x)$$
+>
+>2,3는 $$x$$가 locally optimal point이기 위한 전제조건 $$f(x) < f(z)$$에 대한 모순이므로 귀류법에 의해 locally optimal point $$x$$가 곧 globally optimal point이다.
 
 
 ## convex combination
 
 >$$x_1, ..., x_k$$에 대한 convex combination x는 다음과 같이 정의된다.
 >
->$$x = \theta_1 x_1 + \theta_2 x_2 + ... + \theta_k x_k$$ with $$\theta_1 + ... + \theta_k = 1, \theta_i \ge 0$$
+>$$x = \theta_1 x_1 + \theta_2 x_2 + \cdots + \theta_k x_k$$ with $$\theta_1 + \cdots + \theta_k = 1, \theta_i \ge 0$$
 >
 >$$D$$가 convex set일때 $$x_1, x_2, ..., x_k \in D$$이면, $$x \in D$$이다.

--- a/contents/chapter01/_posts/21-01-28-01_03_goals_and_topics.md
+++ b/contents/chapter01/_posts/21-01-28-01_03_goals_and_topics.md
@@ -36,11 +36,11 @@ owner: "Kyeongmin Woo"
 
 노이즈가 잔뜩 낀 이미지 Data(중간)를 받았을 때, 그 이미지에서 노이즈를 제거하고 True Image(좌측)에 가까운 Solution(우측)을 얻고 싶은 상황이라고 가정하자. 각 pixel값을 $$y_i, i = 1, ..., n$$라고 한다면 이 문제는 다음과 같은 최적화 문제로 정의될 수 있으며, 이는 보통 2d fused lasso 또는 2d total variation denoising problem으로 불린다.
 
->$$\min_{\theta} \frac{1}{2} \Sigma_{i=1}^n (y_i - \theta_{i})^2 + \lambda \Sigma_{(i,j) \in E} \vert \theta_i - \theta_j \vert$$
+>$$\min_{\theta} \frac{1}{2} \sum_{i=1}^n (y_i - \theta_{i})^2 + \lambda \sum_{(i,j) \in E} \vert \theta_i - \theta_j \vert$$
 
 * E: 인접한 모든 $$\theta$$ 사이의 Edge들을 모아둔 집합
-* $$\frac{1}{2} \Sigma_{i=1}^n (y_i - \theta_{i})^2$$: Least squares loss. $$\theta$$가 $$y$$에 가까워지게 한다.
-* $$\Sigma_{(i,j) \in E} \vert \theta_i - \theta_j \vert$$: Total variation smoothing. 인접한 pixel 간 값의 변화가 이미지 전반에 거쳐 그리 많지 않을때 (piecewise constant) 이용할 수 있는 방법이다. 이와 같이 올바른 smoothing 기법의 선택을 위해서는 대상의 특성이 충분히 고려되어야 한다. (Total variation smoothing에 대한 더 자세한 설명은 참고문헌 1의 챕터 6.1.2와 6.3에서 볼 수 있다.)
+* $$\frac{1}{2} \sum_{i=1}^n (y_i - \theta_{i})^2$$: Least squares loss. $$\theta$$가 $$y$$에 가까워지게 한다.
+* $$\sum_{(i,j) \in E} \vert \theta_i - \theta_j \vert$$: Total variation smoothing. 인접한 pixel 간 값의 변화가 이미지 전반에 거쳐 그리 많지 않을때 (piecewise constant) 이용할 수 있는 방법이다. 이와 같이 올바른 smoothing 기법의 선택을 위해서는 대상의 특성이 충분히 고려되어야 한다. (Total variation smoothing에 대한 더 자세한 설명은 참고문헌 1의 챕터 6.1.2와 6.3에서 볼 수 있다.)
 
 앞서 정의된 convex optimization problem은 [Specialized ADMM](http://stanford.edu/~boyd/admm.html) 알고리즘을 이용하면 20번의 iteration으로 우측과 같은 solution을 얻을 수 있다.
 


### PR DESCRIPTION
### 수정사항
- Local optimal -> Global optimal 증명을 직관적으로 수정했습니다.
- dots 노테이션 및 인덱스 오타 수정
- \Sigma -> \sum 으로 변경