### PR TITLE
[Feature] fix typo in 04-04 and 02-01

### DIFF
--- a/contents/chapter02/_posts/21-01-08-02_01_Affine_and_Convex_Sets.md
+++ b/contents/chapter02/_posts/21-01-08-02_01_Affine_and_Convex_Sets.md
@@ -8,4 +8,4 @@ owner: "Wontak Ryu"
 
 이 절에서는 convex set을 중심으로 하는 개념과 정의를 살펴볼 것이다. 이 절에서는 세 가지 종류의 set을 소개하고 있는데, 이 중 가장 일반적인 set이 affine set이며 affine set에서 범위를 제약해서 정의한 set이 convex set과 cone이다.
 
-재미있는 것은 이 set들은 아주 많은 직선(line) 또는 선분(line segment), 반직선(ray)이 모여있다고 가정하고 있다는 것이다. Affine set은 무수히 많은 line을 모여서 만들어진 것이며, convex set은 무수히 많은 line segment이 모여서 만들어진 것이고 cone은 무수히 많은 ray가 모여서 만들어진 것으로 생각하면 쉽게 이해할 수 있을 것이다. 그리고, cone은 nonnegative homogenous set이라고도 하는데 ray의 한쪽 방향으로만 커지는 성질을 생각하면 왜 이런 이름 붙었는지 쉽게 이해할 수 있을 것이다.
+재미있는 것은 이 set들은 아주 많은 직선(line) 또는 선분(line segment), 반직선(ray)이 모여있다고 가정하고 있다는 것이다. Affine set은 무수히 많은 line을 모여서 만들어진 것이며, convex set은 무수히 많은 line segment이 모여서 만들어진 것이고 cone은 무수히 많은 ray가 모여서 만들어진 것으로 생각하면 쉽게 이해할 수 있을 것이다. 그리고, cone은 nonnegative homogeneous set이라고도 하는데 ray의 한쪽 방향으로만 커지는 성질을 생각하면 왜 이런 이름 붙었는지 쉽게 이해할 수 있을 것이다.

--- a/contents/chapter04/_posts/20-02-08-04_04_Partial_optimization.md
+++ b/contents/chapter04/_posts/20-02-08-04_04_Partial_optimization.md
@@ -33,12 +33,12 @@ $$
 위의 제약조건들은 아래의 제약조건 하나로 표현될 수 있다. <br>
 > $$
 \begin{aligned}
-{\xi}_{i} \ge max\{0, 1 - y_{i} (x_{i}^T \beta + \beta_{0})\} \\
+{\xi}_{i} \ge \max\{0, 1 - y_{i} (x_{i}^T \beta + \beta_{0})\} \\
 \end{aligned}
 $$
 
 
-이때, $$max\{0, 1 - y_{i} (x_{i}^T \beta + \beta_{0})\}$$는 $${\xi}_{i}$$의 하한임을 이용하여 $$\tilde{f}$$를 얻을 수 있다.<br>
+이때, $$\max\{0, 1 - y_{i} (x_{i}^T \beta + \beta_{0})\}$$는 $${\xi}_{i}$$의 하한임을 이용하여 $$\tilde{f}$$를 얻을 수 있다.<br>
 
 
 > $$
@@ -54,6 +54,6 @@ $$
 
 >$$
 \begin{aligned}
-\min_{\beta, \beta_0} \frac{1}{2} \|\beta\|_2^2 + C \sum_{i=1}^{n} max\{0, 1 - y_{i} (x_{i}^{T} \beta + \beta_{0}) \}
+\min_{\beta, \beta_0} \frac{1}{2} \|\beta\|_2^2 + C \sum_{i=1}^{n} \max\{0, 1 - y_{i} (x_{i}^{T} \beta + \beta_{0}) \}
 \end{aligned}
 $$

--- a/contents/chapter04/_posts/20-02-08-04_04_Partial_optimization.md
+++ b/contents/chapter04/_posts/20-02-08-04_04_Partial_optimization.md
@@ -24,7 +24,7 @@ Non-separable set에 대한 SVM 문제는 다음과 같이 정의된다.
 \begin{aligned}
 &\min_{\beta, \beta_{0}, \xi} &&\frac{1}{2}\|\beta\|_2^2 + C \sum_{i=1}^{n} \xi_{i} \\
 &\text{subject to} &&{\xi}_{i} \ge 0, \\ 
-&&&y_{i}(x_{i})^T \beta + \beta_{0}) \ge 1 - {\xi}_{i}, \\
+&&&y_{i}(x_{i}^T \beta + \beta_{0}) \ge 1 - {\xi}_{i}, \\
 &&&i = 1, .., n \\
 \end{aligned}
 $$
@@ -36,14 +36,14 @@ $$
 {\xi}_{i} \ge max\{0, 1 - y_{i} (x_{i}^T \beta + \beta_{0})\} \\
 \end{aligned}
 $$
- 
+
 
 이때, $$max\{0, 1 - y_{i} (x_{i}^T \beta + \beta_{0})\}$$는 $${\xi}_{i}$$의 하한임을 이용하여 $$\tilde{f}$$를 얻을 수 있다.<br>
 
 
 > $$
 \begin{aligned}
-\frac{1}{2} \|\beta\|_{2}^{2} + C \sum_{i=1}^{n} {\xi}_{i} &\ge \frac{1}{2} \|\beta\|_{2}^{2} + C \sum_{i=1}^{n} max({0, 1 - y_{i} (x_{i}^T \beta + \beta_{0})})\\
+\frac{1}{2} \|\beta\|_{2}^{2} + C \sum_{i=1}^{n} {\xi}_{i} &\ge \frac{1}{2} \|\beta\|_{2}^{2} + C \sum_{i=1}^{n} \max({0, 1 - y_{i} (x_{i}^T \beta + \beta_{0})})\\
 &= \min\{\frac{1}{2} \|\beta\|_{2}^{2} + C \sum_{i=1}^{n} \xi_{i} \quad | \quad \xi_{i} \ge 0, \ y_{i}(x_{i}^T \beta + \beta_{0}) \ge 1 - \xi_{i}, \ i = 1, .., n\} \\
 &= \tilde{f}(\beta, \beta_{0}) \\
 \end{aligned}


### PR DESCRIPTION
## 04-04
- 괄호 오류 수정 (Related to https://github.com/convex-optimization-for-all/convex-optimization-for-all.github.io/issues/234#issuecomment-2415485741)
- max -> \max 로 수정

## 02-01
- fix typo related to https://github.com/convex-optimization-for-all/convex-optimization-for-all.github.io/issues/223#issuecomment-1829257177