### PR TITLE
fix typo in chapter06

### DIFF
--- a/contents/chapter06/_posts/21-03-20-06_00_gradient_descent.md
+++ b/contents/chapter06/_posts/21-03-20-06_00_gradient_descent.md
@@ -12,4 +12,4 @@ owner: "Kyeongmin Woo"
 
 Gradient descent가 수렴하려면 몇 가지 전제 조건이 필요하다. 이런 전제 조건이 만족된다면 gradient descent가 얼마나 빠르게 수렴할 수 있는지 계산해 볼 수 있다. 또한, Strong Convexity를 만족하게 되면 수렴은 기하급수적으로 빨라지게 된다. 이 경우에 수렴 속도도 살펴볼 것이다.
 
-Gradient descent를 응용한 방법으로 gradient boosting과 stochastic gradient decent에 대해서도 살펴보도록 하겠다.
+Gradient descent를 응용한 방법으로 gradient boosting과 stochastic gradient descent에 대해서도 살펴보도록 하겠다.

--- a/contents/chapter06/_posts/21-03-20-06_01_gradient_descent.md
+++ b/contents/chapter06/_posts/21-03-20-06_01_gradient_descent.md
@@ -14,7 +14,7 @@ Gradient descent는 제약조건이 없는 convex이고 differentiable한 functi
 참고로, optimal value는 $$f^{*} = min_x f(x)$$로 optimal은 $$x^{*}$$로 표기한다.
 
 
-#### Gradient decent method
+#### Gradient descent method
 Gradient descent는 초기 점 $$x^{(0)} \in R^n$$을 선택하고 다음 식을 반복적으로 실행해서 임의의 조건을 만족하면 종료하게 된다.
 > $$x^{(k)} = x^{(k-1)} - t_k \nabla f(x^{(k-1)}), k = 1, 2, 3, . . .$$, $$t_k \gt 0$$
 
@@ -47,7 +47,7 @@ Gradient descent는 초기 점 $$x^{(0)} \in R^n$$을 선택하고 다음 식을
 </p>
 </figure>
 
-## Gradient decent interpretation
+## Gradient descent interpretation
 Gradient descent는 함수를 2차 식으로 근사한 후 함수의 최소 위치를 다음 위치로 선택하는 방법이다.
 
 이 과정을 보이기 위해 함수 $$f$$를 2차 Taylor 식으로 전개해보자.

--- a/contents/chapter06/_posts/21-03-20-06_02_01_fixed_step_size.md
+++ b/contents/chapter06/_posts/21-03-20-06_02_01_fixed_step_size.md
@@ -6,7 +6,7 @@ order: 4
 owner: "Kyeongmin Woo"
 ---
 
-Gradient decent에서 step size를 찾는 가장 단순한 방법은 모든 반복에서 t를 고정하는 것이다.  하지만 step size $$t_k = t$$, $$k = 1, 2, 3, ...$$의 크기에 따라 수렴할 수도 있으고 발산할 수도 있다. 
+Gradient descent에서 step size를 찾는 가장 단순한 방법은 모든 반복에서 t를 고정하는 것이다.  하지만 step size $$t_k = t$$, $$k = 1, 2, 3, ...$$의 크기에 따라 수렴할 수도 있으고 발산할 수도 있다. 
 
 예를 들어 아래 그림을 보면 함수 $$f(x) = (10 x_1^2 + x_2^2) / 2$$에 대해 gradient descent를 수행을 보여주고 있다.
 

--- a/contents/chapter06/_posts/21-03-20-06_03_01_convergence_analysis_and_proof.md
+++ b/contents/chapter06/_posts/21-03-20-06_03_01_convergence_analysis_and_proof.md
@@ -22,7 +22,7 @@ f(x^{(k)}) - f^{*} \le  \frac{ \lVert x^{(0)} - x^{*} \rVert^2_2 }{2tk}
 \end{align}
 $$
 
-Gradient decent가 fixed step size일때 convergence rate $$O(1/k)$$가 된다. 또한, $$f(x^{(k)}) - f^{*} \le \epsilon$$라면 $$O(1/\epsilon)$$의 반복이 필요하다.
+Gradient descent가 fixed step size일때 convergence rate $$O(1/k)$$가 된다. 또한, $$f(x^{(k)}) - f^{*} \le \epsilon$$라면 $$O(1/\epsilon)$$의 반복이 필요하다.
 
 ## Proof
 

--- a/contents/chapter06/_posts/21-03-20-06_04_gradient_boosting.md
+++ b/contents/chapter06/_posts/21-03-20-06_04_gradient_boosting.md
@@ -14,7 +14,7 @@ owner: "Kyeongmin Woo"
 
 
 #### [참고] Functional gradient descent 알고리즘
-**Gradient boosting**은 Llew Mason, Jonathan Baxter, Peter Bartlett and Marcus Frean에 의해 functional gradient descent 알고리즘으로 소개되었다.  Functional gradient descent 알고리즘은 함수 공간에 대해서 loss function을 최적화하는 알고리즘으로 gradient의 음수 방향을 갖는 함수를 반복적으로 선택함으로써 gradient decent를 수행한다.
+**Gradient boosting**은 Llew Mason, Jonathan Baxter, Peter Bartlett and Marcus Frean에 의해 functional gradient descent 알고리즘으로 소개되었다.  Functional gradient descent 알고리즘은 함수 공간에 대해서 loss function을 최적화하는 알고리즘으로 gradient의 음수 방향을 갖는 함수를 반복적으로 선택함으로써 gradient descent를 수행한다.
 
 * 자세한 내용은 [Gradient Boosting](https://en.wikipedia.org/wiki/Gradient_boosting) 참조
 


### PR DESCRIPTION
## 변경 사항
chapter06(Gradient Descent)의 여러 포스트에서 반복되던 "decent" 오타를 "descent"로 수정했습니다.

## 수정한 파일
- 21-03-20-06_00_gradient_descent.md
- 21-03-20-06_01_gradient_descent.md
- 21-03-20-06_02_01_fixed_step_size.md
- 21-03-20-06_03_01_convergence_analysis_and_proof.md
- 21-03-20-06_04_gradient_boosting.md

## 참고
이전 브랜치명(bugfix/chapter06-fix-typo)이 기존에 병합된 브랜치(#183)와 이름이 겹쳐, 
PR의 비교 대상(base)이 main이 아닌 다른 브랜치로 잘못 설정되었습니다. 이로 인해 관련 없는 커밋과 
파일까지 diff에 포함되는 문제가 있어, 브랜치명을 변경하여 다시 올렸습니다.